### PR TITLE
fix travis badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+
+language: go
+go:
+  - 1.7
+  - 1.8
+
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# go-execplus
+# go-execplus  [![Build Status](https://travis-ci.org/Originate/go-execplus/branches)](https://travis-ci.org/Originate/go-execplus)
 
 An abstraction around [os/exec.Cmd](https://golang.org/pkg/os/exec/#Cmd)
 that allows you to:
 
 * wait for specific text to appear in the output
 * receive output chunks via a channel
+
+Requires Go 1.7 or above.
 
 See the tests for examples

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# go-execplus  [![Build Status](https://travis-ci.org/Originate/go-execplus/branches)](https://travis-ci.org/Originate/go-execplus)
+# go-execplus  [![Build Status](https://travis-ci.org/Originate/go-execplus.svg?branch=master)](https://travis-ci.org/Originate/go-execplus/branches)
 
 An abstraction around [os/exec.Cmd](https://golang.org/pkg/os/exec/#Cmd)
 that allows you to:


### PR DESCRIPTION
Sorry my comment was referring to the second url. The first url is used as the image src. The second is the href for the link