### PR TITLE
fix bad release

### DIFF
--- a/cmd_plus.go
+++ b/cmd_plus.go
@@ -106,10 +106,8 @@ func (c *CmdPlus) Start() error {
 		// Start scanning for output chunks after the command has started
 		// in order to avoid a race condition around the stdout file descriptor
 		// between scanning and c.Cmd.Start()
-		go func() {
-			c.scanForOutputChunks(stdoutScanner, c.stdoutClosed)
-			c.scanForOutputChunks(stderrScanner, c.stderrClosed)
-		}()
+		go c.scanForOutputChunks(stdoutScanner, c.stdoutClosed)
+		go c.scanForOutputChunks(stderrScanner, c.stderrClosed)
 	}()
 	return c.Cmd.Start()
 }

--- a/test_executables/output_chunks
+++ b/test_executables/output_chunks
@@ -2,6 +2,6 @@
 
 echo "chunk 1"
 echo "special chunk 2"
-echo "chunk 3"
+echo "chunk 3" 1>&2
 sleep 4
 echo "late chunk 4"


### PR DESCRIPTION
0.7.0 has a bug where it wasn't listening on stderr. This is because `scanForOutputChunks` blocks